### PR TITLE
Only use deployment information if an environment variable is set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,13 +277,15 @@ publishing {
       }
     }
   }
-  repositories {
-    maven {
-      credentials {
-        username = "$ossrhUsername"
-        password = "$ossrhPassword"
+  if (System.getenv('MAVEN_CENTRAL_DEPLOY') == 'true') {
+    repositories {
+      maven {
+        credentials {
+          username = "$ossrhUsername"
+          password = "$ossrhPassword"
+        }
+        url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
       }
-      url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
     }
   }
 }


### PR DESCRIPTION
Only use deployment information if the environment variable "MAVEN_CENTRAL_DEPLOY" is set.

Fixes #3.